### PR TITLE
added support for joomlapass field for automatic password conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Joomla To Wordpress PHP Script
 4. Type in Browser http://www.site-url-wordpress-dir/jwp/index.php.
 5. Click links one by one for best and correct results
 
+# Users
+Once users are imported, their Joomla password hash will be stored in the `joomlapass`
+field in `wp_usermeta`. Then, use [this plugin](https://github.com/asmartin/joomla-to-wordpress-migrated-users-authentication-plugin) to automatically check a user's password when he/she
+logs in and if it matches the Joomla hash, insert the password in the Wordpress format (thus completing the conversion).
+
 # Notes
 * Field in Joomla and Wordpress Can be change from time to time so you have to replace them as needed
 * In wp-config.php on debug mode you will see any error that script is facing.

--- a/user.php
+++ b/user.php
@@ -20,17 +20,22 @@ if ( $users ) {
         $user_metadata_capabilities = array(
             'user_id'    => $user->id,
             'meta_key'   => 'wp_capabilities',
-            'meta_value' => 'a:1:{s:13:"administrator";s:1:"1";}'  // change administrator if you want to
+            'meta_value' => 'a:1:{s:10:"subscriber";b:1;}'  // change subscriber to something else if you want to
+        );
+        $user_metadata_joomlapass = array(
+            'user_id'    => $user->id,
+            'meta_key'   => 'joomlapass',
+            'meta_value' => $user->password
         );
         $user_metadata_user_level = array(
             'user_id'    => $user->id,
             'meta_key'   => 'wp_user_level',
-            'meta_value' => '10' // change wp_user_level if you want to
+            'meta_value' => '0' // change wp_user_level if you want to
         );
 
         $wpdb->insert(''. WPDP_PREFIX . 'users', $user_data);
-        $wpdb->insert(''. WPDP_PREFIX . 'usermeta', $user_metadata_capabilities);
-        $wpdb->insert(''. WPDP_PREFIX . 'usermeta', $user_metadata_user_level);
+        $wpdb->insert(''. WPDP_PREFIX . 'usermeta', $user_metadata_joomlapass);
+//        $wpdb->insert(''. WPDP_PREFIX . 'usermeta', $user_metadata_user_level);
 
         //In Simple SQL
         /*


### PR DESCRIPTION
This adds support for the `joomlapass` field that [this plugin](https://github.com/asmartin/joomla-to-wordpress-migrated-users-authentication-plugin) uses to automatically convert user passwords to the Wordpress password format on the next login